### PR TITLE
Mock request data access

### DIFF
--- a/Example/Shock.xcodeproj/project.pbxproj
+++ b/Example/Shock.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		6DF677011F87CC8500E1783A /* MyRoutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF676FF1F87CC8200E1783A /* MyRoutes.swift */; };
 		6DF677041F87CF0100E1783A /* simple-route.json in Resources */ = {isa = PBXBuildFile; fileRef = 6DF677031F87CF0100E1783A /* simple-route.json */; };
 		AED1F3F6A7E2F3CE6580EE5D /* Pods_Shock_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF96B6D5EA1A806DC03BC3FF /* Pods_Shock_Tests.framework */; };
+		CBF416CD230DE1F20087A914 /* ApiCallRequestDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBF416CB230DE1EA0087A914 /* ApiCallRequestDataTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -69,6 +70,7 @@
 		80CFA7CB8BE3BF594CE240EC /* Pods-Shock_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Shock_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Shock_Example/Pods-Shock_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		8F256468ADABF7F27A3F94C1 /* Shock.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Shock.podspec; path = ../Shock.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		BAEA53249A2F84CEFE92ED63 /* Pods-Shock_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Shock_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Shock_Tests/Pods-Shock_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		CBF416CB230DE1EA0087A914 /* ApiCallRequestDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiCallRequestDataTests.swift; sourceTree = "<group>"; };
 		F4C361D0B990A1E623A12117 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		FF96B6D5EA1A806DC03BC3FF /* Pods_Shock_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Shock_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -158,6 +160,7 @@
 				6D410ED5206D203D00A2D79D /* MethodTests.swift */,
 				6D10776E1FA9EB21006BB9C8 /* TemplatedRouteTests.swift */,
 				607FACEB1AFB9204008FA782 /* Tests.swift */,
+				CBF416CB230DE1EA0087A914 /* ApiCallRequestDataTests.swift */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
 			);
 			path = Tests;
@@ -399,6 +402,7 @@
 			files = (
 				6D10776D1FA9E67E006BB9C8 /* CustomRouteTests.swift in Sources */,
 				6D410ED6206D203D00A2D79D /* MethodTests.swift in Sources */,
+				CBF416CD230DE1F20087A914 /* ApiCallRequestDataTests.swift in Sources */,
 				6DE276E91F8761F300C9F194 /* HTTPClient.swift in Sources */,
 				6D10776F1FA9EB21006BB9C8 /* TemplatedRouteTests.swift in Sources */,
 				607FACEC1AFB9204008FA782 /* Tests.swift in Sources */,

--- a/Shock.podspec
+++ b/Shock.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'Shock'
-  s.version          = '2.0.0'
+  s.version          = '2.0.1'
   s.summary          = 'A HTTP mocking framework written in Swift.'
 
   s.description      = <<-DESC


### PR DESCRIPTION
Can pass in a closure from test case to obtain the API call request data so that we can gather all the data like headers, query parameters etc of the Request call