### PR TITLE
Add forceAllCallsToBeMocked method to MockServer

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - GRMustache (7.3.2):
     - JRSwizzle (~> 1.0)
   - JRSwizzle (1.0)
-  - Shock (3.0.1):
+  - Shock (3.1.0):
     - GRMustache (~> 7.3.2)
     - Swifter (~> 1.4.7)
   - Swifter (1.4.7)
@@ -23,7 +23,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   GRMustache: ebe6104fd30a6d22c1f36af131e19e2dbf7cd292
   JRSwizzle: dd5ead5d913a0f29e7f558200165849f006bb1e3
-  Shock: dfe46333bf3a5c250bbe85cd1d3e5a8b4d4090ff
+  Shock: d5a053f70f75be97950f78568e3a9e24591638c7
   Swifter: 2327ef5d872c638aebab79646ce494af508b0c8f
 
 PODFILE CHECKSUM: f2aa1fe1bd8633dab49f7d1b56c94fb4c395c003

--- a/README.md
+++ b/README.md
@@ -181,6 +181,16 @@ let secondRoute: MockHTTPRoute = .simple(method: .get, urlPath: "/route2", code:
 let collectionRoute: MockHTTPRoute = .collection(routes: [ firstRoute, secondRoute ])
 ```
 
+### Force all calls to be mocked
+
+In some case you might prefer to have all the calls to be mocked so that the tests can reliably run without internet connection. You can force this behaviour like so:
+
+```
+server.forceAllCallsToBeMocked()
+```
+
+Your tests will hit an assert if any call wasn't mocked.
+
 ## License
 
 Shock is available under Apache License 2.0.  See the LICENSE file for more info.

--- a/Shock.podspec
+++ b/Shock.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'Shock'
-  s.version          = '3.0.1'
+  s.version          = '3.1.0'
   s.summary          = 'A HTTP mocking framework written in Swift.'
 
   s.description      = <<-DESC

--- a/Shock/Classes/MockServer.swift
+++ b/Shock/Classes/MockServer.swift
@@ -38,6 +38,13 @@ public class MockServer {
         server.stop()
     }
     
+    public func forceAllCallsToBeMocked() {
+        server.notFoundHandler = { request in
+            assertionFailure("Not handled: \(request.method) \(request.path)")
+            return .internalServerError
+        }
+    }
+    
     public var hostURL: String {
         return "http://localhost:\(port)"
     }


### PR DESCRIPTION
Add `forceAllCallsToBeMocked` method to `MockServer` to allow forcing all calls to be mocked.