### PR TITLE
Xcode 12: Update Swifter

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -6,7 +6,6 @@ use_frameworks!
 
 target 'Shock_Example' do
   pod 'Shock', :path => '../'
-  pod 'Swifter', :git => 'https://github.com/httpswift/swifter.git', :branch => 'xcode12-swift5'
 
   target 'Shock_Tests' do
     inherit! :search_paths

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -6,6 +6,7 @@ use_frameworks!
 
 target 'Shock_Example' do
   pod 'Shock', :path => '../'
+  pod 'Swifter', :git => 'https://github.com/httpswift/swifter.git', :branch => 'xcode12-swift5'
 
   target 'Shock_Tests' do
     inherit! :search_paths

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -2,10 +2,10 @@ PODS:
   - GRMustache (7.3.2):
     - JRSwizzle (~> 1.0)
   - JRSwizzle (1.0)
-  - Shock (4.0.0):
+  - Shock (4.0.1):
     - GRMustache (~> 7.3.2)
-    - Swifter (~> 1.5.0-rc.1)
-  - Swifter (1.5.0-rc.1)
+    - Swifter (~> 1.5.0)
+  - Swifter (1.5.0)
 
 DEPENDENCIES:
   - Shock (from `../`)
@@ -23,8 +23,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   GRMustache: ebe6104fd30a6d22c1f36af131e19e2dbf7cd292
   JRSwizzle: dd5ead5d913a0f29e7f558200165849f006bb1e3
-  Shock: 427c4a84fa4e556789556dc27dfe5b79d0d137cc
-  Swifter: 256770a124f078f6e7d969333cb75989f5445f20
+  Shock: 10167fcc9fc3faff2fdf2b23aff372faa11ccf93
+  Swifter: e71dd674404923d7f03ebb03f3f222d1c570bc8e
 
 PODFILE CHECKSUM: f2aa1fe1bd8633dab49f7d1b56c94fb4c395c003
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -9,23 +9,31 @@ PODS:
 
 DEPENDENCIES:
   - Shock (from `../`)
+  - Swifter (from `https://github.com/httpswift/swifter.git`, branch `xcode12-swift5`)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
     - GRMustache
     - JRSwizzle
-    - Swifter
 
 EXTERNAL SOURCES:
   Shock:
     :path: "../"
+  Swifter:
+    :branch: xcode12-swift5
+    :git: https://github.com/httpswift/swifter.git
+
+CHECKOUT OPTIONS:
+  Swifter:
+    :commit: 14334e0318a919fec72d3adc85aff66b80c31a73
+    :git: https://github.com/httpswift/swifter.git
 
 SPEC CHECKSUMS:
   GRMustache: ebe6104fd30a6d22c1f36af131e19e2dbf7cd292
   JRSwizzle: dd5ead5d913a0f29e7f558200165849f006bb1e3
   Shock: a92e14ac44d4ee9c956c33a8649d4a77c80d45a9
-  Swifter: 2327ef5d872c638aebab79646ce494af508b0c8f
+  Swifter: 1c6973f7cef90e92f305db5caca72ab414d7948e
 
-PODFILE CHECKSUM: f2aa1fe1bd8633dab49f7d1b56c94fb4c395c003
+PODFILE CHECKSUM: a82710504a6dfd8bf031cba22e1abafa85c5a3fe
 
 COCOAPODS: 1.8.4

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -4,36 +4,28 @@ PODS:
   - JRSwizzle (1.0)
   - Shock (4.0.0):
     - GRMustache (~> 7.3.2)
-    - Swifter (~> 1.4.7)
-  - Swifter (1.4.7)
+    - Swifter (~> 1.5.0-rc.1)
+  - Swifter (1.5.0-rc.1)
 
 DEPENDENCIES:
   - Shock (from `../`)
-  - Swifter (from `https://github.com/httpswift/swifter.git`, branch `xcode12-swift5`)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
     - GRMustache
     - JRSwizzle
+    - Swifter
 
 EXTERNAL SOURCES:
   Shock:
     :path: "../"
-  Swifter:
-    :branch: xcode12-swift5
-    :git: https://github.com/httpswift/swifter.git
-
-CHECKOUT OPTIONS:
-  Swifter:
-    :commit: 14334e0318a919fec72d3adc85aff66b80c31a73
-    :git: https://github.com/httpswift/swifter.git
 
 SPEC CHECKSUMS:
   GRMustache: ebe6104fd30a6d22c1f36af131e19e2dbf7cd292
   JRSwizzle: dd5ead5d913a0f29e7f558200165849f006bb1e3
-  Shock: a92e14ac44d4ee9c956c33a8649d4a77c80d45a9
-  Swifter: 1c6973f7cef90e92f305db5caca72ab414d7948e
+  Shock: 427c4a84fa4e556789556dc27dfe5b79d0d137cc
+  Swifter: 256770a124f078f6e7d969333cb75989f5445f20
 
-PODFILE CHECKSUM: a82710504a6dfd8bf031cba22e1abafa85c5a3fe
+PODFILE CHECKSUM: f2aa1fe1bd8633dab49f7d1b56c94fb4c395c003
 
 COCOAPODS: 1.8.4

--- a/Shock.podspec
+++ b/Shock.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'Shock'
-  s.version          = '4.0.0'
+  s.version          = '4.0.1'
   s.summary          = 'A HTTP mocking framework written in Swift.'
 
   s.description      = <<-DESC
@@ -26,6 +26,6 @@ Shock lets you quickly and painlessly provided mock responses for web requests m
 
   s.source_files = 'Shock/Classes/**/*'
 
-  s.dependency 'Swifter', '~> 1.5.0-rc.1'
+  s.dependency 'Swifter', '~> 1.5.0'
   s.dependency 'GRMustache', '~> 7.3.2'
 end

--- a/Shock.podspec
+++ b/Shock.podspec
@@ -26,6 +26,6 @@ Shock lets you quickly and painlessly provided mock responses for web requests m
 
   s.source_files = 'Shock/Classes/**/*'
 
-  s.dependency 'Swifter', '~> 1.4.7'
+  s.dependency 'Swifter', '~> 1.5.0-rc.1'
   s.dependency 'GRMustache', '~> 7.3.2'
 end


### PR DESCRIPTION
Swifter 1.4.7 had an [issue](https://github.com/httpswift/swifter/issues/454) compiling in Xcode 12. This PR updates the pinned version of Swifter in the Shock podspec to 1.5.0.