### PR TITLE
SPM support

### DIFF
--- a/Example/Shock.xcodeproj/project.pbxproj
+++ b/Example/Shock.xcodeproj/project.pbxproj
@@ -13,13 +13,14 @@
 		607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 607FACD91AFB9204008FA782 /* Main.storyboard */; };
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
-		607FACEC1AFB9204008FA782 /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACEB1AFB9204008FA782 /* Tests.swift */; };
+		607FACEC1AFB9204008FA782 /* RouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACEB1AFB9204008FA782 /* RouteTests.swift */; };
 		6D10776D1FA9E67E006BB9C8 /* CustomRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D10776C1FA9E67E006BB9C8 /* CustomRouteTests.swift */; };
 		6D10776F1FA9EB21006BB9C8 /* TemplatedRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D10776E1FA9EB21006BB9C8 /* TemplatedRouteTests.swift */; };
 		6D410ED6206D203D00A2D79D /* MethodTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D410ED5206D203D00A2D79D /* MethodTests.swift */; };
 		6D718E371F8777660070B764 /* testSimpleRoute.txt in Resources */ = {isa = PBXBuildFile; fileRef = 6D718E361F8777660070B764 /* testSimpleRoute.txt */; };
 		6D718E391F877AB30070B764 /* testRedirectRoute.txt in Resources */ = {isa = PBXBuildFile; fileRef = 6D718E381F877AB30070B764 /* testRedirectRoute.txt */; };
 		6D7BDCF61FA72BC300488DB5 /* testCustomRoute.txt in Resources */ = {isa = PBXBuildFile; fileRef = 6D7BDCF51FA72BC300488DB5 /* testCustomRoute.txt */; };
+		6D9D7BBB25248ED7000FE60F /* ParallelServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D9D7BBA25248ED7000FE60F /* ParallelServerTests.swift */; };
 		6DAD6AC120D7B87E0088FEDB /* template-route.json.mustache in Resources */ = {isa = PBXBuildFile; fileRef = 6DAD6AC020D7B87E0088FEDB /* template-route.json.mustache */; };
 		6DAD6AC320D7BC3C0088FEDB /* custom-route.json in Resources */ = {isa = PBXBuildFile; fileRef = 6DAD6AC220D7BC3C0088FEDB /* custom-route.json */; };
 		6DE276E91F8761F300C9F194 /* HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE276E81F8761F300C9F194 /* HTTPClient.swift */; };
@@ -54,13 +55,14 @@
 		607FACDF1AFB9204008FA782 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 		607FACE51AFB9204008FA782 /* Shock_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Shock_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACEA1AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		607FACEB1AFB9204008FA782 /* Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests.swift; sourceTree = "<group>"; };
+		607FACEB1AFB9204008FA782 /* RouteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteTests.swift; sourceTree = "<group>"; };
 		6D10776C1FA9E67E006BB9C8 /* CustomRouteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomRouteTests.swift; sourceTree = "<group>"; };
 		6D10776E1FA9EB21006BB9C8 /* TemplatedRouteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TemplatedRouteTests.swift; sourceTree = "<group>"; };
 		6D410ED5206D203D00A2D79D /* MethodTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MethodTests.swift; sourceTree = "<group>"; };
 		6D718E361F8777660070B764 /* testSimpleRoute.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = testSimpleRoute.txt; sourceTree = "<group>"; };
 		6D718E381F877AB30070B764 /* testRedirectRoute.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = testRedirectRoute.txt; sourceTree = "<group>"; };
 		6D7BDCF51FA72BC300488DB5 /* testCustomRoute.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = testCustomRoute.txt; sourceTree = "<group>"; };
+		6D9D7BBA25248ED7000FE60F /* ParallelServerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParallelServerTests.swift; sourceTree = "<group>"; };
 		6DAD6AC020D7B87E0088FEDB /* template-route.json.mustache */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "template-route.json.mustache"; sourceTree = "<group>"; };
 		6DAD6AC220D7BC3C0088FEDB /* custom-route.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "custom-route.json"; sourceTree = "<group>"; };
 		6DE276E81F8761F300C9F194 /* HTTPClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPClient.swift; sourceTree = "<group>"; };
@@ -155,12 +157,13 @@
 			isa = PBXGroup;
 			children = (
 				6DE276E71F868DDC00C9F194 /* Fixtures */,
+				CBF416CB230DE1EA0087A914 /* ApiCallRequestDataTests.swift */,
 				6D10776C1FA9E67E006BB9C8 /* CustomRouteTests.swift */,
 				6DE276E81F8761F300C9F194 /* HTTPClient.swift */,
 				6D410ED5206D203D00A2D79D /* MethodTests.swift */,
+				6D9D7BBA25248ED7000FE60F /* ParallelServerTests.swift */,
+				607FACEB1AFB9204008FA782 /* RouteTests.swift */,
 				6D10776E1FA9EB21006BB9C8 /* TemplatedRouteTests.swift */,
-				607FACEB1AFB9204008FA782 /* Tests.swift */,
-				CBF416CB230DE1EA0087A914 /* ApiCallRequestDataTests.swift */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
 			);
 			path = Tests;
@@ -400,12 +403,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6D9D7BBB25248ED7000FE60F /* ParallelServerTests.swift in Sources */,
 				6D10776D1FA9E67E006BB9C8 /* CustomRouteTests.swift in Sources */,
 				6D410ED6206D203D00A2D79D /* MethodTests.swift in Sources */,
 				CBF416CD230DE1F20087A914 /* ApiCallRequestDataTests.swift in Sources */,
 				6DE276E91F8761F300C9F194 /* HTTPClient.swift in Sources */,
 				6D10776F1FA9EB21006BB9C8 /* TemplatedRouteTests.swift in Sources */,
-				607FACEC1AFB9204008FA782 /* Tests.swift in Sources */,
+				607FACEC1AFB9204008FA782 /* RouteTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/Shock.xcodeproj/xcshareddata/xcschemes/Shock-Example.xcscheme
+++ b/Example/Shock.xcodeproj/xcshareddata/xcschemes/Shock-Example.xcscheme
@@ -40,20 +40,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "607FACE41AFB9204008FA782"
-               BuildableName = "Shock_Tests.xctest"
-               BlueprintName = "Shock_Tests"
-               ReferencedContainer = "container:Shock.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -63,8 +51,19 @@
             ReferencedContainer = "container:Shock.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "607FACE41AFB9204008FA782"
+               BuildableName = "Shock_Tests.xctest"
+               BlueprintName = "Shock_Tests"
+               ReferencedContainer = "container:Shock.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -86,8 +85,6 @@
             ReferencedContainer = "container:Shock.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Example/Shock/MyRoutes.swift
+++ b/Example/Shock/MyRoutes.swift
@@ -13,7 +13,9 @@ class MyRoutes {
 	
 	private let routes: [MockHTTPRoute]
 	
-	private let server = MockServer(port: 9091, bundle: Bundle.main)
+    // NOTE: Ensure this port is outside of the range used by unit tests
+    // (i.e. not in range <9090...9099> )
+	private let server = MockServer(port: 9990, bundle: Bundle.main)
 	
 	init() {
 		

--- a/Example/Tests/ApiCallRequestDataTests.swift
+++ b/Example/Tests/ApiCallRequestDataTests.swift
@@ -20,7 +20,7 @@ class ApiCallRequestDataTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        server = MockServer(port: 9090, bundle: Bundle(for: Tests.self))
+        server = MockServer(portRange: 9090...9099, bundle: Bundle(for: ApiCallRequestDataTests.self))
         server.start()
         server.onRequestReceived = { route, request in
             self.requestsCache.cache.append((route, request))

--- a/Example/Tests/CustomRouteTests.swift
+++ b/Example/Tests/CustomRouteTests.swift
@@ -16,7 +16,7 @@ class CustomRouteTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        server = MockServer(port: 9090, bundle: Bundle(for: Tests.self))
+        server = MockServer(portRange: 9090...9099, bundle: Bundle(for: CustomRouteTests.self))
         server.start()
     }
     

--- a/Example/Tests/MethodTests.swift
+++ b/Example/Tests/MethodTests.swift
@@ -15,7 +15,7 @@ class MethodTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        server = MockServer(port: 9090, bundle: Bundle(for: Tests.self))
+        server = MockServer(portRange: 9090...9099, bundle: Bundle(for: MethodTests.self))
         server.start()
     }
     

--- a/Example/Tests/ParallelServerTests.swift
+++ b/Example/Tests/ParallelServerTests.swift
@@ -1,0 +1,33 @@
+//
+//  ParallelServerTests.swift
+//  Shock_Tests
+//
+//  Created by Jack Newcombe on 30/09/2020.
+//  Copyright © 2020 CocoaPods. All rights reserved.
+//
+
+import XCTest
+import Shock
+
+class ParallelServerTests: XCTestCase {
+
+    func testParallelServerPortAssignment() throws {
+        let range: ClosedRange<Int> = 9090...9099
+        
+        var servers: [MockServer] = []
+        
+        range.forEach { port in
+            let server = MockServer(portRange: range, bundle: Bundle(for: ParallelServerTests.self))
+            server.start()
+            servers.append(server)
+        }
+        
+        servers.enumerated().forEach { index, server in
+            let port = UInt16(9090 + index)
+            XCTAssertEqual(server.selectedPort, port)
+            server.stop()
+        }
+        
+    }
+
+}

--- a/Example/Tests/RouteTests.swift
+++ b/Example/Tests/RouteTests.swift
@@ -1,5 +1,5 @@
 //
-//  Tests.swift
+//  RouteTests.swift
 //  Shock
 //
 //  Created by Jack Newcombe on 27/06/2018.
@@ -9,13 +9,13 @@
 import XCTest
 @testable import Shock
 
-class Tests: XCTestCase {
+class RouteTests: XCTestCase {
     
     var server: MockServer!
     
     override func setUp() {
         super.setUp()
-        server = MockServer(port: 9090, bundle: Bundle(for: Tests.self))
+        server = MockServer(portRange: 9090...9099, bundle: Bundle(for: RouteTests.self))
         server.start()
     }
     

--- a/Example/Tests/TemplatedRouteTests.swift
+++ b/Example/Tests/TemplatedRouteTests.swift
@@ -15,7 +15,7 @@ class TemplatedRouteTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        server = MockServer(port: 9090, bundle: Bundle(for: Tests.self))
+        server = MockServer(portRange: 9090...9099, bundle: Bundle(for: TemplatedRouteTests.self))
         server.start()
     }
     

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,36 @@
+// swift-tools-version:5.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Shock",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "Shock",
+            targets: ["Shock"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+        .package(name: "Swifter",
+                 url: "git@github.com:httpswift/swifter.git",
+                 from: "1.5.0"),
+        .package(name: "Mustache",
+                 url: "git@github.com:groue/GRMustache.swift.git",
+                 from: "4.0.0")
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "Shock",
+            dependencies: ["Swifter", "Mustache"],
+            path: "Shock/Classes/"),
+        .testTarget(
+            name: "Shock-Tests",
+            dependencies: ["Shock"],
+            path: "Example/Tests"),
+    ]
+)


### PR DESCRIPTION
Adds SPM support.

NOTE: Tests don't function yet but this is because you have two choices w.r.t resources: 

1) **Swift Version <= 5.2 *** Do crazy copying of files into different locations, and/or restructure files in project, and add lots of custom code into the main library for loading resources from filesystem (vs bundle)
2) ** Swift Version >= 5.3 *** Add a `resources` parameter to the target and point it at the resources.

So, yeah, option 2 obviously!