### PR TITLE
Flexible complex routes

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
   - GRMustache.swift (4.0.1)
   - JustLog (3.1.3):
     - SwiftyBeaver (~> 1.9.1)
-  - Shock (5.1.0):
+  - Shock (5.1.1):
     - GRMustache.swift (~> 4.0.1)
     - SwiftNIOHTTP1 (~> 2.22.1)
   - SwiftNIO (2.22.1):
@@ -54,7 +54,7 @@ SPEC CHECKSUMS:
   CNIOSHA1: fd4d38fb42778ed971a75d87530f842106d4b4f4
   GRMustache.swift: a6436504284b22b4b05daf5f46f77bd3fe00a9a2
   JustLog: c1b12fe8fc6a7c22cc31dd874fe7776eaa7089d2
-  Shock: bf0897783c236a737439c9791f1598141def9246
+  Shock: 242e4df327943989ef8041d578a5fc45592e4442
   SwiftNIO: 763188229de166e046cc8975383cca388832e992
   SwiftNIOConcurrencyHelpers: 34d2e9d4d2b7886fa765086e845e6b19417be927
   SwiftNIOHTTP1: c0a9ce48ba256f349af4f09648a0e0939b11a65c

--- a/Example/Shock.xcodeproj/project.pbxproj
+++ b/Example/Shock.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0463BE14252DA52700C18221 /* ClosureMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0463BE13252DA52700C18221 /* ClosureMiddlewareTests.swift */; };
 		0463BE1A252DA54700C18221 /* ShockTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0463BE19252DA54700C18221 /* ShockTestCase.swift */; };
 		14739D0D25262B640031286B /* SocketServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14739D0C25262B640031286B /* SocketServerTests.swift */; };
+		14C308E82649781700B85451 /* testCustomRoute2.txt in Resources */ = {isa = PBXBuildFile; fileRef = 14C308E72649781700B85451 /* testCustomRoute2.txt */; };
 		28CF36BB9C72A116B41A9CCA /* Pods_Shock_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 504237DD0DF4E81BD4C74B63 /* Pods_Shock_Example.framework */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
 		607FACD81AFB9204008FA782 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD71AFB9204008FA782 /* ViewController.swift */; };
@@ -48,6 +49,7 @@
 		0463BE13252DA52700C18221 /* ClosureMiddlewareTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosureMiddlewareTests.swift; sourceTree = "<group>"; };
 		0463BE19252DA54700C18221 /* ShockTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShockTestCase.swift; sourceTree = "<group>"; };
 		14739D0C25262B640031286B /* SocketServerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketServerTests.swift; sourceTree = "<group>"; };
+		14C308E72649781700B85451 /* testCustomRoute2.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = testCustomRoute2.txt; sourceTree = "<group>"; };
 		2AF495106DF32828591B5E10 /* Pods-Shock_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Shock_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Shock_Tests/Pods-Shock_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		2DEE7FFDC29CFACFFE3400E0 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		4A7A38CD9EF252172E5C9478 /* Pods-Shock_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Shock_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-Shock_Example/Pods-Shock_Example.release.xcconfig"; sourceTree = "<group>"; };
@@ -211,6 +213,7 @@
 				6D718E361F8777660070B764 /* testSimpleRoute.txt */,
 				6D718E381F877AB30070B764 /* testRedirectRoute.txt */,
 				6D7BDCF51FA72BC300488DB5 /* testCustomRoute.txt */,
+				14C308E72649781700B85451 /* testCustomRoute2.txt */,
 			);
 			path = Fixtures;
 			sourceTree = "<group>";
@@ -333,6 +336,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				14C308E82649781700B85451 /* testCustomRoute2.txt in Resources */,
 				6DF676FC1F8793F700E1783A /* testTemplatedRoute.mustache in Resources */,
 				6D718E391F877AB30070B764 /* testRedirectRoute.txt in Resources */,
 				6D718E371F8777660070B764 /* testSimpleRoute.txt in Resources */,

--- a/Example/Tests/CustomRouteTests.swift
+++ b/Example/Tests/CustomRouteTests.swift
@@ -114,14 +114,30 @@ class CustomRouteTests: ShockTestCase {
             code: 200,
             filename: "testCustomRoute.txt"
         )
-        server.setup(route: route)
+        let query2 = "item3=value3&item4=value4"
+        let route2: MockHTTPRoute = .custom(
+            method: .get,
+            urlPath: "/custom-with-query",
+            query: ["item3": "value3", "item4": "value4"],
+            requestHeaders: [:],
+            responseHeaders: [:],
+            code: 200,
+            filename: "testCustomRoute2.txt"
+        )
+        let routes: MockHTTPRoute = .collection(routes: [route, route2])
+        server.setup(route: routes)
         
         let expectation = self.expectation(description: "Expect 200 response with response body")
-        
         HTTPClient.get(url: "\(server.hostURL)/custom-with-query?\(query)") { code, body, headers, error in
             expectation.fulfill()
             XCTAssertEqual(code, 200)
             XCTAssertEqual(body, "testCustomRoute test fixture\n")
+        }
+        let expectation2 = self.expectation(description: "Expect 200 response with response body")
+        HTTPClient.get(url: "\(server.hostURL)/custom-with-query?\(query2)") { code, body, headers, error in
+            expectation2.fulfill()
+            XCTAssertEqual(code, 200)
+            XCTAssertEqual(body, "testCustomRoute2 test fixture\n")
         }
         self.waitForExpectations(timeout: timeout, handler: nil)
     }

--- a/Example/Tests/Fixtures/testCustomRoute2.txt
+++ b/Example/Tests/Fixtures/testCustomRoute2.txt
@@ -1,0 +1,1 @@
+testCustomRoute2 test fixture

--- a/Example/Tests/RouteTests.swift
+++ b/Example/Tests/RouteTests.swift
@@ -74,4 +74,121 @@ class RouteTests: ShockTestCase {
         }
         self.waitForExpectations(timeout: 2.5, handler: nil)
     }
+    
+    func testSimpleRouteEquivalence() {
+        var route1 = MockHTTPRoute.simple(method: .get, urlPath: "foo/bar", code: 200, filename: nil)
+        var route2 = MockHTTPRoute.simple(method: .get, urlPath: "foo/bar", code: 200, filename: nil)
+        XCTAssertEqual(route1, route2, "Simple gets should be equal")
+        route1 = MockHTTPRoute.simple(method: .get, urlPath: "foo/bar", code: 200, filename: nil)
+        route2 = MockHTTPRoute.simple(method: .get, urlPath: "foo/bar", code: 404, filename: nil)
+        XCTAssertEqual(route1, route2, "Codes are different, should not affect equality")
+        route1 = MockHTTPRoute.simple(method: .get, urlPath: "foo/bar", code: 200, filename: nil)
+        route2 = MockHTTPRoute.simple(method: .get, urlPath: "bar/foo", code: 200, filename: nil)
+        XCTAssertNotEqual(route1, route2, "Paths are different, should not be equal")
+        route1 = MockHTTPRoute.simple(method: .get, urlPath: "foo/bar", code: 200, filename: nil)
+        route2 = MockHTTPRoute.simple(method: .post, urlPath: "foo/bar", code: 200, filename: nil)
+        XCTAssertNotEqual(route1, route2, "Methods are different, should not be equal")
+    }
+    
+    func testCustomRouteEquivalence() {
+        var route1 = MockHTTPRoute.custom(method: .get, urlPath: "foo/bar", query: ["query":"value"],
+                                          requestHeaders: ["HTTPHeader":"false"], responseHeaders: ["HTTPHeader":"true"], code: 200, filename: nil)
+        var route2 = MockHTTPRoute.custom(method: .get, urlPath: "foo/bar", query: ["query":"value"],
+                                          requestHeaders: ["HTTPHeader":"false"], responseHeaders: ["HTTPHeader":"true"], code: 200, filename: nil)
+        XCTAssertEqual(route1, route2, "Custom routes should be equal")
+        route1 = MockHTTPRoute.custom(method: .get, urlPath: "foo/bar", query: ["query":"value"],
+                                      requestHeaders: ["HTTPHeader":"false"], responseHeaders: ["HTTPHeader":"true"], code: 200, filename: nil)
+        route2 = MockHTTPRoute.custom(method: .get, urlPath: "foo/bar", query: ["query":"value"],
+                                      requestHeaders: ["HTTPHeader":"false"], responseHeaders: ["HTTPHeader":"true"], code: 404, filename: nil)
+        XCTAssertEqual(route1, route2, "Codes are different, should not affect equality")
+        route1 = MockHTTPRoute.custom(method: .get, urlPath: "foo/bar", query: ["query":"value"],
+                                      requestHeaders: ["HTTPHeader":"false"], responseHeaders: ["HTTPHeader":"true"], code: 200, filename: nil)
+        route2 = MockHTTPRoute.custom(method: .get, urlPath: "foo/bar", query: ["query":"value2"],
+                                      requestHeaders: ["HTTPHeader":"false"], responseHeaders: ["HTTPHeader":"true"], code: 200, filename: nil)
+        XCTAssertNotEqual(route1, route2, "Queries are different, should not be equal")
+        route1 = MockHTTPRoute.custom(method: .get, urlPath: "foo/bar", query: ["query":"value"],
+                                      requestHeaders: ["HTTPHeader":"false"], responseHeaders: ["HTTPHeader":"true"], code: 200, filename: nil)
+        route2 = MockHTTPRoute.custom(method: .get, urlPath: "foo/bar", query: ["query":"value"],
+                                      requestHeaders: ["HTTPHeader":"true"], responseHeaders: ["HTTPHeader":"true"], code: 200, filename: nil)
+        XCTAssertNotEqual(route1, route2, "Request headers are different, should not be equal")
+        route1 = MockHTTPRoute.custom(method: .get, urlPath: "foo/bar", query: ["query":"value"],
+                                      requestHeaders: ["HTTPHeader":"false"], responseHeaders: ["HTTPHeader":"true"], code: 200, filename: nil)
+        route2 = MockHTTPRoute.custom(method: .get, urlPath: "bar/foo", query: ["query":"value"],
+                                      requestHeaders: ["HTTPHeader":"false"], responseHeaders: ["HTTPHeader":"true"], code: 200, filename: nil)
+        XCTAssertNotEqual(route1, route2, "Paths are different, should not be equal")
+        route1 = MockHTTPRoute.custom(method: .get, urlPath: "foo/bar", query: ["query":"value"],
+                                      requestHeaders: ["HTTPHeader":"false"], responseHeaders: ["HTTPHeader":"true"], code: 200, filename: nil)
+        route2 = MockHTTPRoute.custom(method: .post, urlPath: "foo/bar", query: ["query":"value"],
+                                      requestHeaders: ["HTTPHeader":"false"], responseHeaders: ["HTTPHeader":"true"], code: 200, filename: nil)
+        XCTAssertNotEqual(route1, route2, "Methods are different, should not be equal")
+    }
+    
+    func testTemplateRouteEquivalence() {
+        var route1 = MockHTTPRoute.template(method: .get, urlPath: "foo/bar", code: 200, filename: nil, templateInfo: ["Value" : 1])
+        var route2 = MockHTTPRoute.template(method: .get, urlPath: "foo/bar", code: 200, filename: nil, templateInfo: ["Value" : 1])
+        XCTAssertEqual(route1, route2, "Template routes should be equal")
+        route1 = MockHTTPRoute.template(method: .get, urlPath: "foo/bar", code: 200, filename: nil, templateInfo: ["Value" : 1])
+        route2 = MockHTTPRoute.template(method: .get, urlPath: "foo/bar", code: 200, filename: nil, templateInfo: ["Value" : 2])
+        XCTAssertEqual(route1, route2, "Templates are different, should not affect equality")
+        route1 = MockHTTPRoute.template(method: .get, urlPath: "foo/bar", code: 200, filename: nil, templateInfo: ["Value" : 1])
+        route2 = MockHTTPRoute.template(method: .get, urlPath: "foo/bar", code: 404, filename: nil, templateInfo: ["Value" : 1])
+        XCTAssertEqual(route1, route2, "Codes are different, should not affect equality")
+        route1 = MockHTTPRoute.template(method: .get, urlPath: "foo/bar", code: 200, filename: nil, templateInfo: ["Value" : 1])
+        route2 = MockHTTPRoute.template(method: .get, urlPath: "bar/foo", code: 200, filename: nil, templateInfo: ["Value" : 1])
+        XCTAssertNotEqual(route1, route2, "Paths are different, should not be equal")
+        route1 = MockHTTPRoute.template(method: .get, urlPath: "foo/bar", code: 200, filename: nil, templateInfo: ["Value" : 1])
+        route2 = MockHTTPRoute.template(method: .post, urlPath: "foo/bar", code: 200, filename: nil, templateInfo: ["Value" : 1])
+        XCTAssertNotEqual(route1, route2, "Methods are different, should not be equal")
+    }
+    
+    func testRedirectRouteEquivalence() {
+        var route1 = MockHTTPRoute.redirect(urlPath: "foo/bar", destination: "bar/foo")
+        var route2 = MockHTTPRoute.redirect(urlPath: "foo/bar", destination: "bar/foo")
+        XCTAssertEqual(route1, route2, "Redirect routes should be equal")
+        route1 = MockHTTPRoute.redirect(urlPath: "foo/bar", destination: "bar/foo")
+        route2 = MockHTTPRoute.redirect(urlPath: "bar/foo", destination: "bar/foo")
+        XCTAssertNotEqual(route1, route2, "Paths are different, should not be equal")
+        route1 = MockHTTPRoute.redirect(urlPath: "foo/bar", destination: "bar/foo")
+        route2 = MockHTTPRoute.redirect(urlPath: "foo/bar", destination: "foo/bar")
+        XCTAssertEqual(route1, route2, "Destinations are different, should not affect equality")
+    }
+    
+    func testTimeoutRouteEquivalence() {
+        var route1 = MockHTTPRoute.timeout(method: .get, urlPath: "foo/bar", timeoutInSeconds: 1)
+        var route2 = MockHTTPRoute.timeout(method: .get, urlPath: "foo/bar", timeoutInSeconds: 1)
+        XCTAssertEqual(route1, route2, "Timeout routes should be equal")
+        route1 = MockHTTPRoute.timeout(method: .get, urlPath: "foo/bar", timeoutInSeconds: 1)
+        route2 = MockHTTPRoute.timeout(method: .get, urlPath: "foo/bar", timeoutInSeconds: 2)
+        XCTAssertEqual(route1, route2, "Timeouts are different, should not affect equality")
+        route1 = MockHTTPRoute.timeout(method: .get, urlPath: "foo/bar", timeoutInSeconds: 1)
+        route2 = MockHTTPRoute.timeout(method: .get, urlPath: "bar/foo", timeoutInSeconds: 1)
+        XCTAssertNotEqual(route1, route2, "Paths are different, should not be equal")
+        route1 = MockHTTPRoute.timeout(method: .get, urlPath: "foo/bar", timeoutInSeconds: 1)
+        route2 = MockHTTPRoute.timeout(method: .post, urlPath: "foo/bar", timeoutInSeconds: 1)
+        XCTAssertNotEqual(route1, route2, "Methods are different, should not be equal")
+    }
+    
+    func testCollectionRouteEquivalence() {
+        var route1 = MockHTTPRoute.collection(routes: [
+            .simple(method: .get, urlPath: "foo/bar", code: 200, filename: nil)
+        ])
+        var route2 = MockHTTPRoute.collection(routes: [
+            .simple(method: .get, urlPath: "foo/bar", code: 200, filename: nil)
+        ])
+        XCTAssertEqual(route1, route2, "Collection routes should be equal")
+        route1 = MockHTTPRoute.collection(routes: [
+            .simple(method: .get, urlPath: "foo/bar", code: 200, filename: nil)
+        ])
+        route2 = MockHTTPRoute.collection(routes: [
+            .simple(method: .get, urlPath: "foo/bar", code: 404, filename: nil)
+        ])
+        XCTAssertEqual(route1, route2, "Codes are different, should not affect equality")
+        route1 = MockHTTPRoute.collection(routes: [
+            .simple(method: .get, urlPath: "foo/bar", code: 200, filename: nil)
+        ])
+        route2 = MockHTTPRoute.collection(routes: [
+            .simple(method: .get, urlPath: "bar/foo", code: 200, filename: nil)
+        ])
+        XCTAssertNotEqual(route1, route2, "Paths are different, should not be equal")
+    }
 }

--- a/Example/Tests/RouteTests.swift
+++ b/Example/Tests/RouteTests.swift
@@ -191,4 +191,103 @@ class RouteTests: ShockTestCase {
         ])
         XCTAssertNotEqual(route1, route2, "Paths are different, should not be equal")
     }
+    
+    func testSimpleRouteHash() {
+        let route1 = MockHTTPRoute.simple(method: .get, urlPath: "foo/bar", code: 200, filename: nil)
+        let route2 = MockHTTPRoute.simple(method: .get, urlPath: "foo/bar", code: 200, filename: nil)
+        var dict = [MockHTTPRoute : String]()
+        dict[route1] = "Foo"
+        XCTAssertEqual(dict.count, 1, "There should be one element in the dictionary")
+        dict[route2] = "Bar"
+        XCTAssertEqual(dict.count, 1, "There should still be one element in the dictionary")
+        let route3 = MockHTTPRoute.simple(method: .post, urlPath: "foo/bar", code: 200, filename: nil)
+        dict[route3] = "Foo"
+        XCTAssertEqual(dict.count, 2, "There should now be two elements in the dictionary")
+        XCTAssertEqual(dict[route2], "Bar")
+        XCTAssertEqual(dict[route3], "Foo")
+    }
+    
+    func testCustomRouteHash() {
+        let route1 = MockHTTPRoute.custom(method: .get, urlPath: "foo/bar", query: ["query":"value"],
+                                          requestHeaders: ["HTTPHeader":"false"], responseHeaders: ["HTTPHeader":"true"], code: 200, filename: nil)
+        let route2 = MockHTTPRoute.custom(method: .get, urlPath: "foo/bar", query: ["query":"value"],
+                                          requestHeaders: ["HTTPHeader":"false"], responseHeaders: ["HTTPHeader":"true"], code: 200, filename: nil)
+        var dict = [MockHTTPRoute : String]()
+        dict[route1] = "Foo"
+        XCTAssertEqual(dict.count, 1, "There should be one element in the dictionary")
+        dict[route2] = "Bar"
+        XCTAssertEqual(dict.count, 1, "There should still be one element in the dictionary")
+        let route3 = MockHTTPRoute.custom(method: .post, urlPath: "foo/bar", query: ["query":"value"],
+                                          requestHeaders: ["HTTPHeader":"false"], responseHeaders: ["HTTPHeader":"true"], code: 200, filename: nil)
+        dict[route3] = "Foo"
+        XCTAssertEqual(dict.count, 2, "There should now be two elements in the dictionary")
+        XCTAssertEqual(dict[route2], "Bar")
+        XCTAssertEqual(dict[route3], "Foo")
+    }
+    
+    func testTemplateRouteHash() {
+        let route1 = MockHTTPRoute.template(method: .get, urlPath: "foo/bar", code: 200, filename: nil, templateInfo: ["Value" : 1])
+        let route2 = MockHTTPRoute.template(method: .get, urlPath: "foo/bar", code: 200, filename: nil, templateInfo: ["Value" : 1])
+        var dict = [MockHTTPRoute : String]()
+        dict[route1] = "Foo"
+        XCTAssertEqual(dict.count, 1, "There should be one element in the dictionary")
+        dict[route2] = "Bar"
+        XCTAssertEqual(dict.count, 1, "There should still be one element in the dictionary")
+        let route3 = MockHTTPRoute.template(method: .post, urlPath: "foo/bar", code: 200, filename: nil, templateInfo: ["Value" : 1])
+        dict[route3] = "Foo"
+        XCTAssertEqual(dict.count, 2, "There should now be two elements in the dictionary")
+        XCTAssertEqual(dict[route2], "Bar")
+        XCTAssertEqual(dict[route3], "Foo")
+    }
+    
+    func testRedirectRouteHash() {
+        let route1 = MockHTTPRoute.redirect(urlPath: "foo/bar", destination: "bar/foo")
+        let route2 = MockHTTPRoute.redirect(urlPath: "foo/bar", destination: "bar/foo")
+        var dict = [MockHTTPRoute : String]()
+        dict[route1] = "Foo"
+        XCTAssertEqual(dict.count, 1, "There should be one element in the dictionary")
+        dict[route2] = "Bar"
+        XCTAssertEqual(dict.count, 1, "There should still be one element in the dictionary")
+        let route3 = MockHTTPRoute.redirect(urlPath: "bar/foo", destination: "bar/foo")
+        dict[route3] = "Foo"
+        XCTAssertEqual(dict.count, 2, "There should now be two elements in the dictionary")
+        XCTAssertEqual(dict[route2], "Bar")
+        XCTAssertEqual(dict[route3], "Foo")
+    }
+    
+    func testCollectionRouteHash() {
+        let route1 = MockHTTPRoute.collection(routes: [
+            .simple(method: .get, urlPath: "foo/bar", code: 200, filename: nil)
+        ])
+        let route2 = MockHTTPRoute.collection(routes: [
+            .simple(method: .get, urlPath: "foo/bar", code: 200, filename: nil)
+        ])
+        var dict = [MockHTTPRoute : String]()
+        dict[route1] = "Foo"
+        XCTAssertEqual(dict.count, 1, "There should be one element in the dictionary")
+        dict[route2] = "Bar"
+        XCTAssertEqual(dict.count, 1, "There should still be one element in the dictionary")
+        let route3 = MockHTTPRoute.collection(routes: [
+            .simple(method: .post, urlPath: "foo/bar", code: 200, filename: nil)
+        ])
+        dict[route3] = "Foo"
+        XCTAssertEqual(dict.count, 2, "There should now be two elements in the dictionary")
+        XCTAssertEqual(dict[route2], "Bar")
+        XCTAssertEqual(dict[route3], "Foo")
+    }
+    
+    func testTimeoutRouteHash() {
+        let route1 = MockHTTPRoute.timeout(method: .get, urlPath: "foo/bar", timeoutInSeconds: 1)
+        let route2 = MockHTTPRoute.timeout(method: .get, urlPath: "foo/bar", timeoutInSeconds: 1)
+        var dict = [MockHTTPRoute : String]()
+        dict[route1] = "Foo"
+        XCTAssertEqual(dict.count, 1, "There should be one element in the dictionary")
+        dict[route2] = "Bar"
+        XCTAssertEqual(dict.count, 1, "There should still be one element in the dictionary")
+        let route3 = MockHTTPRoute.timeout(method: .post, urlPath: "foo/bar", timeoutInSeconds: 1)
+        dict[route3] = "Foo"
+        XCTAssertEqual(dict.count, 2, "There should now be two elements in the dictionary")
+        XCTAssertEqual(dict[route2], "Bar")
+        XCTAssertEqual(dict[route3], "Foo")
+    }
 }

--- a/Shock.podspec
+++ b/Shock.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'Shock'
-  s.version          = '5.1.0'
+  s.version          = '5.1.1'
   s.summary          = 'A HTTP mocking framework written in Swift.'
 
   s.description      = <<-DESC

--- a/Shock/Classes/Middleware/Middleware.swift
+++ b/Shock/Classes/Middleware/Middleware.swift
@@ -87,8 +87,8 @@ class MiddlewareService {
         let responseContext = _MiddlewareResponseContext()
         
         let context = _MiddlewareContext(requestContext: requestContext,
-                                     responseContext: responseContext,
-                                     notFoundHandler: notFoundHandler) {
+                                         responseContext: responseContext,
+                                         notFoundHandler: notFoundHandler) {
             if (middleware.count - 1) > 0 {
                 self.executeAll(forRequest: request, middleware: Array(middleware[1...]))
             }

--- a/Shock/Classes/Middleware/MockRoutesMiddleware.swift
+++ b/Shock/Classes/Middleware/MockRoutesMiddleware.swift
@@ -22,7 +22,8 @@ class MockRoutesMiddleware: Middleware {
         
         guard let handler = router.handlerForMethod(context.requestContext.method,
                                                     path: context.requestContext.path,
-                                                    params: context.requestContext.params) else {
+                                                    params: context.requestContext.params,
+                                                    headers: context.requestContext.headers) else {
             return context.next()
         }
         

--- a/Shock/Classes/Middleware/MockRoutesMiddleware.swift
+++ b/Shock/Classes/Middleware/MockRoutesMiddleware.swift
@@ -24,6 +24,7 @@ class MockRoutesMiddleware: Middleware {
                                                     path: context.requestContext.path,
                                                     params: context.requestContext.params,
                                                     headers: context.requestContext.headers) else {
+            context.notFoundHandler?(context.requestContext, context.responseContext)
             return context.next()
         }
         

--- a/Shock/Classes/Middleware/MockRoutesMiddleware.swift
+++ b/Shock/Classes/Middleware/MockRoutesMiddleware.swift
@@ -21,7 +21,8 @@ class MockRoutesMiddleware: Middleware {
     func execute(withContext context: MiddlewareContext) {
         
         guard let handler = router.handlerForMethod(context.requestContext.method,
-                                                  path: context.requestContext.path) else {
+                                                    path: context.requestContext.path,
+                                                    params: context.requestContext.params) else {
             return context.next()
         }
         

--- a/Shock/Classes/MockHTTPRoute.swift
+++ b/Shock/Classes/MockHTTPRoute.swift
@@ -180,4 +180,26 @@ extension MockHTTPRoute: Hashable {
         }
         return false
     }
+    
+    public func hash(into hasher: inout Hasher) {
+        switch self {
+        case .simple(method: let method, urlPath: let urlPath, _, _):
+            hasher.combine(method)
+            hasher.combine(urlPath)
+        case .custom(method: let method, urlPath: let urlPath, query: let query, _, _, _, _):
+            hasher.combine(method)
+            hasher.combine(urlPath)
+            hasher.combine(query)
+        case .template(method: let method, urlPath: let urlPath, _, _, _):
+            hasher.combine(method)
+            hasher.combine(urlPath)
+        case .redirect(urlPath: let urlPath, _):
+            hasher.combine(urlPath)
+        case .collection(routes: let routes):
+            hasher.combine(routes)
+        case .timeout(method: let method, urlPath: let urlPath, _):
+            hasher.combine(method)
+            hasher.combine(urlPath)
+        }
+    }
 }

--- a/Shock/Classes/MockHTTPRoute.swift
+++ b/Shock/Classes/MockHTTPRoute.swift
@@ -152,18 +152,18 @@ public enum MockHTTPRoute {
     
 }
 
-extension MockHTTPRoute: Equatable {
+extension MockHTTPRoute: Hashable {
     public static func == (lhs: MockHTTPRoute, rhs: MockHTTPRoute) -> Bool {
-        if case MockHTTPRoute.simple(let lhsMethod, let lhsUrlPath, let lhsCode, _) = lhs,
-           case MockHTTPRoute.simple(let rhsMethod, let rhsUrlPath, let rhsCode, _) = rhs {
+        if case MockHTTPRoute.simple(let lhsMethod, let lhsUrlPath, let _, _) = lhs,
+           case MockHTTPRoute.simple(let rhsMethod, let rhsUrlPath, let _, _) = rhs {
             return lhsMethod == rhsMethod && lhsUrlPath == rhsUrlPath
         }
-        if case MockHTTPRoute.custom(let lhsMethod, let lhsUrlPath, let lhsQuery, let lhsRequestHeaders, let lhsResponseHeaders, let lhsCode, _) = lhs,
-           case MockHTTPRoute.custom(let rhsMethod, let rhsUrlPath, let rhsQuery, let rhsRequestHeaders, let rhsResponseHeaders, let rhsCode, _) = rhs {
-            return lhsMethod == rhsMethod && lhsUrlPath == rhsUrlPath
+        if case MockHTTPRoute.custom(let lhsMethod, let lhsUrlPath, let lhsQuery, let lhsRequestHeaders, _, let _, _) = lhs,
+           case MockHTTPRoute.custom(let rhsMethod, let rhsUrlPath, let rhsQuery, let rhsRequestHeaders, _, let _, _) = rhs {
+            return lhsMethod == rhsMethod && lhsUrlPath == rhsUrlPath && lhsQuery == rhsQuery && lhsRequestHeaders == rhsRequestHeaders
         }
-        if case MockHTTPRoute.template(let lhsMethod, let lhsUrlPath, let lhsCode, _, _) = lhs,
-           case MockHTTPRoute.template(let rhsMethod, let rhsUrlPath, let rhsCode, _, _) = rhs {
+        if case MockHTTPRoute.template(let lhsMethod, let lhsUrlPath, let _, _, _) = lhs,
+           case MockHTTPRoute.template(let rhsMethod, let rhsUrlPath, let _, _, _) = rhs {
             return lhsMethod == rhsMethod && lhsUrlPath == rhsUrlPath
         }
         if case MockHTTPRoute.redirect(let lhsUrlPath, _) = lhs,

--- a/Shock/Classes/MockHTTPRoute.swift
+++ b/Shock/Classes/MockHTTPRoute.swift
@@ -151,3 +151,33 @@ public enum MockHTTPRoute {
     }
     
 }
+
+extension MockHTTPRoute: Equatable {
+    public static func == (lhs: MockHTTPRoute, rhs: MockHTTPRoute) -> Bool {
+        if case MockHTTPRoute.simple(let lhsMethod, let lhsUrlPath, let lhsCode, _) = lhs,
+           case MockHTTPRoute.simple(let rhsMethod, let rhsUrlPath, let rhsCode, _) = rhs {
+            return lhsMethod == rhsMethod && lhsUrlPath == rhsUrlPath
+        }
+        if case MockHTTPRoute.custom(let lhsMethod, let lhsUrlPath, let lhsQuery, let lhsRequestHeaders, let lhsResponseHeaders, let lhsCode, _) = lhs,
+           case MockHTTPRoute.custom(let rhsMethod, let rhsUrlPath, let rhsQuery, let rhsRequestHeaders, let rhsResponseHeaders, let rhsCode, _) = rhs {
+            return lhsMethod == rhsMethod && lhsUrlPath == rhsUrlPath
+        }
+        if case MockHTTPRoute.template(let lhsMethod, let lhsUrlPath, let lhsCode, _, _) = lhs,
+           case MockHTTPRoute.template(let rhsMethod, let rhsUrlPath, let rhsCode, _, _) = rhs {
+            return lhsMethod == rhsMethod && lhsUrlPath == rhsUrlPath
+        }
+        if case MockHTTPRoute.redirect(let lhsUrlPath, _) = lhs,
+           case MockHTTPRoute.redirect(let rhsUrlPath, _) = rhs {
+            return lhsUrlPath == rhsUrlPath
+        }
+        if case MockHTTPRoute.timeout(let lhsMethod, let lhsUrlPath, _) = lhs,
+           case MockHTTPRoute.timeout(let rhsMethod, let rhsUrlPath, _) = rhs {
+            return lhsMethod == rhsMethod && lhsUrlPath == rhsUrlPath
+        }
+        if case MockHTTPRoute.collection(let lhsRoutes) = lhs,
+           case MockHTTPRoute.collection(let rhsRoutes) = rhs {
+            return lhsRoutes.elementsEqual(rhsRoutes)
+        }
+        return false
+    }
+}

--- a/Shock/Classes/MockHTTPRoute.swift
+++ b/Shock/Classes/MockHTTPRoute.swift
@@ -152,7 +152,9 @@ public enum MockHTTPRoute {
     
 }
 
-extension MockHTTPRoute: Hashable {
+/// The philosophy for Equatable/Hashable `MockHTTPRoute` is anything in the request
+/// part of the route (e.g. `method` or `urlPath`) are part of the identify of the route
+extension MockHTTPRoute: Hashable {    
     public static func == (lhs: MockHTTPRoute, rhs: MockHTTPRoute) -> Bool {
         if case MockHTTPRoute.simple(let lhsMethod, let lhsUrlPath, let _, _) = lhs,
            case MockHTTPRoute.simple(let rhsMethod, let rhsUrlPath, let _, _) = rhs {

--- a/Shock/Classes/MockHTTPServerProtocols.swift
+++ b/Shock/Classes/MockHTTPServerProtocols.swift
@@ -10,7 +10,7 @@ import Foundation
 typealias HandlerClosure = (MiddlewareRequestContext, MiddlewareResponseContext) -> Void
 
 protocol MockHttpRouter {
-    func register(_ method: String, path: String, handler: HandlerClosure?)
+    func register(route: MockHTTPRoute, handler: HandlerClosure?)
 }
 
 protocol MockMethodRoute {
@@ -19,9 +19,9 @@ protocol MockMethodRoute {
 }
 
 extension MockMethodRoute {
-    subscript(path: String) -> HandlerClosure? {
+    subscript(route: MockHTTPRoute) -> HandlerClosure? {
         set {
-            router.register(method, path: path, handler: newValue)
+            router.register(route: route, handler: newValue)
         }
         get { return nil }
     }

--- a/Shock/Classes/MockHTTPServerProtocols.swift
+++ b/Shock/Classes/MockHTTPServerProtocols.swift
@@ -7,8 +7,6 @@
 
 import Foundation
 
-typealias HandlerClosure = (MiddlewareRequestContext, MiddlewareResponseContext) -> Void
-
 protocol MockHttpRouter {
     func register(route: MockHTTPRoute, handler: HandlerClosure?)
 }

--- a/Shock/Classes/MockServer.swift
+++ b/Shock/Classes/MockServer.swift
@@ -126,17 +126,6 @@ Run `netstat -anptcp | grep LISTEN` to check which ports are in use.")
         
         middleware.router.register(route: route) { request, response in
             
-            if let expectedHeaders = route.requestHeaders, !request.headers.contains(expectedHeaders) {
-                self.httpServer.notFoundHandler?(request, response)
-                return
-            }
-            
-            let query = request.queryParams.reduce(into: [String: String]()) { $0[$1.0] = $1.1 }
-            if let expectedQuery = route.query, !query.contains(expectedQuery) {
-                self.httpServer.notFoundHandler?(request, response)
-                return
-            }
-            
             switch route {
             case .redirect(_, let destination):
                 response.statusCode = 301

--- a/Shock/Classes/MockServer.swift
+++ b/Shock/Classes/MockServer.swift
@@ -91,9 +91,13 @@ Run `netstat -anptcp | grep LISTEN` to check which ports are in use.")
             httpServer.notFoundHandler != nil            
         }
         set {
-            httpServer.notFoundHandler = { _, response in
-                response.statusCode = 404
-                response.responseBody = nil
+            if newValue {
+                httpServer.notFoundHandler = { _, response in
+                    response.statusCode = 404
+                    response.responseBody = nil
+                }
+            } else {
+                httpServer.notFoundHandler = nil
             }
         }
     }

--- a/Shock/Classes/MockServer.swift
+++ b/Shock/Classes/MockServer.swift
@@ -120,7 +120,7 @@ Run `netstat -anptcp | grep LISTEN` to check which ports are in use.")
             return
         }
         
-        middleware.router.register(method.rawValue, path: path) { request, response in
+        middleware.router.register(route: route) { request, response in
             
             if let expectedHeaders = route.requestHeaders, !request.headers.contains(expectedHeaders) {
                 self.httpServer.notFoundHandler?(request, response)

--- a/Shock/Classes/NIO/MockNIOHTTPServer.swift
+++ b/Shock/Classes/NIO/MockNIOHTTPServer.swift
@@ -15,7 +15,14 @@ class MockNIOHttpServer: MockNIOBaseServer, MockHttpServer {
     private let router = MockNIOHTTPRouter()
     private let middlewareService = MiddlewareService()
 
-    var notFoundHandler: HandlerClosure?
+    var notFoundHandler: HandlerClosure? {
+        get {
+            middlewareService.notFoundHandler
+        }
+        set {
+            middlewareService.notFoundHandler = newValue
+        }
+    }
     var methodRoutes: [MockHTTPMethod: MockNIOHTTPMethodRoute] = [:]
     
     

--- a/Shock/Classes/NIO/MockNIOHTTPServer.swift
+++ b/Shock/Classes/NIO/MockNIOHTTPServer.swift
@@ -56,11 +56,11 @@ class MockNIOHTTPRouter: MockHttpRouter {
     typealias RouteHandlerMapping = [MockHTTPRoute: HandlerClosure]
     private var routes = [String: RouteHandlerMapping]()
     
-    func handlerForMethod(_ method: String, path: String, params: [String:String]) -> HandlerClosure? {
+    func handlerForMethod(_ method: String, path: String, params: [String:String], headers: [String:String]) -> HandlerClosure? {
         guard let httpMethod = MockHTTPMethod(rawValue: method) else { return nil }
         let methodRoutes = routes[method] ?? RouteHandlerMapping()
         for (candidate, handler) in methodRoutes {
-            if candidate.matches(method: httpMethod, path: path, params: params) {
+            if candidate.matches(method: httpMethod, path: path, params: params, headers: headers) {
                 return handler
             }
         }


### PR DESCRIPTION
Shock now uses the entire route request (method, path, params, etc) for the key in the internal routing dictionary. This makes complex routes much more flexible, allowing registration of multiple routes with the same `urlPath`.

This PR:

- Adds `Equatable` and `Hashable` support to the `MockHTTPRoute` enum (and adds copious tests).
- Uses the `MockHTTPRoute` as the key in the `PathHandlerMapping` (now `RouteHandlerMapping`).
- Moves the `notFoundHandler` to the `MiddlewareContext`.