### PR TITLE
Removed onRequestReceived property

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
   - GRMustache.swift (4.0.1)
   - JustLog (3.1.3):
     - SwiftyBeaver (~> 1.9.1)
-  - Shock (5.1.1):
+  - Shock (6.0.0):
     - GRMustache.swift (~> 4.0.1)
     - SwiftNIOHTTP1 (~> 2.22.1)
   - SwiftNIO (2.22.1):
@@ -54,7 +54,7 @@ SPEC CHECKSUMS:
   CNIOSHA1: fd4d38fb42778ed971a75d87530f842106d4b4f4
   GRMustache.swift: a6436504284b22b4b05daf5f46f77bd3fe00a9a2
   JustLog: c1b12fe8fc6a7c22cc31dd874fe7776eaa7089d2
-  Shock: 242e4df327943989ef8041d578a5fc45592e4442
+  Shock: e8f5c810e5ca8c19e1903a42b2a129a6c0e7b07e
   SwiftNIO: 763188229de166e046cc8975383cca388832e992
   SwiftNIOConcurrencyHelpers: 34d2e9d4d2b7886fa765086e845e6b19417be927
   SwiftNIOHTTP1: c0a9ce48ba256f349af4f09648a0e0939b11a65c

--- a/Example/Tests/ApiCallRequestDataTests.swift
+++ b/Example/Tests/ApiCallRequestDataTests.swift
@@ -12,20 +12,12 @@ import XCTest
 class ApiCallRequestDataTests: XCTestCase {
     
     var server: MockServer!
-    var requestsCache = RequestsCache()
-    
-    struct RequestsCache {
-        var cache: [(route: MockHTTPRoute, request: CacheableRequest)] = []
-    }
     
     override func setUp() {
         super.setUp()
         server = MockServer(portRange: 9090...9099, bundle: Bundle(for: ApiCallRequestDataTests.self))
         server.shouldSendNotFoundForMissingRoutes = true
         server.start()
-        server.onRequestReceived = { route, request in
-            self.requestsCache.cache.append((route, request))
-        }
     }
     
     override func tearDown() {
@@ -45,11 +37,5 @@ class ApiCallRequestDataTests: XCTestCase {
             expectation.fulfill()
         }
         self.waitForExpectations(timeout: 2.0, handler: nil)
-        
-        // Check if the API call request data is accessible
-        for (route, request) in requestsCache.cache{
-            XCTAssertTrue(route.urlPath == "/simple")
-            XCTAssertTrue(request.path == "/simple")
-        }
     }
 }

--- a/Shock.podspec
+++ b/Shock.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'Shock'
-  s.version          = '5.1.1'
+  s.version          = '6.0.0'
   s.summary          = 'A HTTP mocking framework written in Swift.'
 
   s.description      = <<-DESC

--- a/Shock/Classes/MockHTTPRoute.swift
+++ b/Shock/Classes/MockHTTPRoute.swift
@@ -185,13 +185,13 @@ extension MockHTTPRoute: Hashable {
     }
     
     private static func headers(_ lhs: [String:String], contains rhs: [String:String]) -> Bool {
+        guard !(lhs.isEmpty && rhs.isEmpty) else { return true }
         var bigger = lhs
         var smaller = rhs
         if smaller.count != bigger.count {
             bigger = lhs.count > rhs.count ? lhs : rhs
             smaller = lhs.count < rhs.count ? lhs : rhs
         }
-        guard !bigger.isEmpty else { return false }
         guard !smaller.isEmpty else { return true }
         for outer in smaller {
             let result = bigger.contains() { (key: String, value: String) in

--- a/Shock/Classes/MockServer.swift
+++ b/Shock/Classes/MockServer.swift
@@ -28,9 +28,7 @@ public class MockServer {
         httpServer.add(middleware: middleware)
         return middleware
     }()
-    
-    public var onRequestReceived: ((MockHTTPRoute, CacheableRequest) -> Void)?
-    
+
     public var selectedHTTPPort = 0
     public var selectedSocketPort = 0
     


### PR DESCRIPTION
Removed `onRequestReceived` property, which was broken in v5, but never removed. This necessitated a major version bump. Clients can replace `onRequestReceived` very easily with a `ClosureMiddleware` if they still need that functionality. 

Also, a small route equality optimisation.