### PR TITLE
Use HTTPS URLs instead of SSH

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,8 +2,8 @@
   "object": {
     "pins": [
       {
-        "package": "Mustache",
-        "repositoryURL": "git@github.com:groue/GRMustache.swift.git",
+        "package": "GRMustache.swift",
+        "repositoryURL": "https://github.com/groue/GRMustache.swift.git",
         "state": {
           "branch": null,
           "revision": "671e2c5234e829c1f337c9d300bd6d9b21d1c42a",
@@ -12,7 +12,7 @@
       },
       {
         "package": "swift-nio",
-        "repositoryURL": "git@github.com:apple/swift-nio.git",
+        "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
           "revision": "96db8838be60fcbb993fa738e1120fb7f4b99c43",

--- a/Package.swift
+++ b/Package.swift
@@ -14,10 +14,10 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "git@github.com:apple/swift-nio.git",
+        .package(url: "https://github.com/apple/swift-nio.git",
                  from: "2.22.1"),
         .package(name: "Mustache",
-                 url: "git@github.com:groue/GRMustache.swift.git",
+                 url: "https://github.com/groue/GRMustache.swift.git",
                  from: "4.0.0")
     ],
     targets: [


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Replaces the SSH URLs in the Swift Package Manager definition with HTTPS ones.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This resolves the issues reported in https://github.com/justeat/Shock/issues/39.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by dropping into our own project and seeing the problem disappear.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
