### PR TITLE
Update SwiftNIOHTTP1 to 2.38.0

### DIFF
--- a/Shock.podspec
+++ b/Shock.podspec
@@ -28,6 +28,6 @@ Shock lets you quickly and painlessly provided mock responses for HTTP & HTTPs w
   'Shock/Classes/**/*',
   'Shock/Classes/NIO/**/*'
 
-  s.dependency 'SwiftNIOHTTP1', '~> 2.22.1'
+  s.dependency 'SwiftNIOHTTP1', '~> 2.38.0'
   s.dependency 'GRMustache.swift', '~> 4.0.1'
 end


### PR DESCRIPTION
This should fix the compilation issues on Xcode 13.3
I updated SwiftNIOHTTP1 to the latest version

## Description
The app was not compiling after updating to Xcode 13.3

## Motivation and Context
The app was not compiling after updating to Xcode 13.3
https://github.com/justeat/Shock/issues/45

## How Has This Been Tested?
I ran my UI tests against the Shock server successfully

## Screenshots (if appropriate):
-

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
