### PR TITLE
Bump Shock version

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - GRMustache.swift (4.0.1)
   - JustLog (3.1.3):
     - SwiftyBeaver (~> 1.9.1)
-  - Shock (6.1.0):
+  - Shock (6.1.1):
     - GRMustache.swift (~> 4.0.1)
     - SwiftNIOHTTP1 (~> 2.38.0)
   - SwiftNIO (2.38.0):
@@ -72,7 +72,7 @@ SPEC CHECKSUMS:
   CNIOWindows: 1cc6fb2af1d445f52f2d39cecf7069873f7d5b0d
   GRMustache.swift: a6436504284b22b4b05daf5f46f77bd3fe00a9a2
   JustLog: c1b12fe8fc6a7c22cc31dd874fe7776eaa7089d2
-  Shock: cdd389c457828fbfab6f3a4620903bbb68fc779c
+  Shock: 9258930104aad1e7f83b06e8f0ce08bbc15c158c
   SwiftNIO: 9bc23fada7254a38f1417533a4514aabdcb7cf31
   SwiftNIOConcurrencyHelpers: ec57adfc490604a341904994fbf98de61a8b5497
   SwiftNIOCore: 156fd84c03dc877a5f22d0ba575745cafe4a83ca
@@ -83,4 +83,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: cdfd396ee6b50582fc686483708cd0e9514aada3
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.10.2

--- a/Shock.podspec
+++ b/Shock.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'Shock'
-  s.version          = '6.1.0'
+  s.version          = '6.1.1'
   s.summary          = 'A HTTP mocking framework written in Swift.'
 
   s.description      = <<-DESC


### PR DESCRIPTION
To publish new version of pod we need to bump it

## Description
That [PR](https://github.com/justeat/Shock/pull/46) was merged without bumping the pod version. As result we can't publish new version of pod. Following PR should fix it

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.